### PR TITLE
Unstripe <hr> elements

### DIFF
--- a/components/markdown.scss
+++ b/components/markdown.scss
@@ -5,10 +5,9 @@ $margin: 15px;
 // container with .markdown-body on it should render generally well. It also
 // includes some GitHub Flavored Markdown specific styling (like @mentions)
 .markdown-body {
-
+  overflow: hidden;
   font-size: 15px;
   line-height: 1.7;
-  overflow: hidden;
   word-wrap: break-word;
 
   & > *:first-child {
@@ -25,29 +24,29 @@ $margin: 15px;
   }
 
   a.anchor {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
     display: block;
     padding-right: 6px;
     padding-left: 30px;
     margin-left: -30px;
     cursor: pointer;
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
 
     &:focus {
-      outline: none
+      outline: none;
     }
   }
 
   // Headings
   h1, h2, h3, h4, h5, h6 {
-    margin: 1em 0 $margin;
+    position: relative;
     padding: 0;
+    margin: 1em 0 $margin;
     font-weight: bold;
     line-height: 1.7;
     cursor: text;
-    position: relative;
 
     .octicon-link {
       display: none;
@@ -55,11 +54,11 @@ $margin: 15px;
     }
 
     &:hover a.anchor {
-      text-decoration: none;
-      line-height: 1;
+      top: 15%;
       padding-left: 8px;
       margin-left: -30px;
-      top: 15%;
+      line-height: 1;
+      text-decoration: none;
 
       .octicon-link {
         display: inline-block;
@@ -93,8 +92,8 @@ $margin: 15px;
   }
 
   h6 {
-    color: #777;
     font-size: 1em;
+    color: #777;
   }
 
   p,
@@ -106,12 +105,11 @@ $margin: 15px;
   }
 
   hr {
-    background: transparent url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAYAAAAECAYAAACtBE5DAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNSBNYWNpbnRvc2giIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6OENDRjNBN0E2NTZBMTFFMEI3QjRBODM4NzJDMjlGNDgiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6OENDRjNBN0I2NTZBMTFFMEI3QjRBODM4NzJDMjlGNDgiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDo4Q0NGM0E3ODY1NkExMUUwQjdCNEE4Mzg3MkMyOUY0OCIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo4Q0NGM0E3OTY1NkExMUUwQjdCNEE4Mzg3MkMyOUY0OCIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PqqezsUAAAAfSURBVHjaYmRABcYwBiM2QSA4y4hNEKYDQxAEAAIMAHNGAzhkPOlYAAAAAElFTkSuQmCC) repeat-x 0 0;
-    border: 0 none;
-    color: #ccc;
     height: 4px;
     padding: 0;
     margin: $margin 0;
+    background-color: #e7e7e7;
+    border: 0 none;
   }
 
   // Lists, Blockquotes & Such
@@ -119,8 +117,8 @@ $margin: 15px;
     padding-left: 30px;
 
     &.no-list {
-      list-style-type: none;
       padding: 0;
+      list-style-type: none;
     }
   }
 
@@ -160,22 +158,22 @@ $margin: 15px;
   }
 
   dl dt {
-    font-size: 14px;
-    font-weight: bold;
-    font-style: italic;
     padding: 0;
     margin-top: $margin;
+    font-size: 14px;
+    font-style: italic;
+    font-weight: bold;
   }
 
   dl dd {
-    margin-bottom: $margin;
     padding: 0 15px;
+    margin-bottom: $margin;
   }
 
   blockquote {
-    border-left: 4px solid #DDD;
     padding: 0 15px;
     color: #777;
+    border-left: 4px solid #DDD;
 
     & > :first-child {
       margin-top: 0px;
@@ -188,23 +186,23 @@ $margin: 15px;
 
   // Tables
   table {
+    display: block;
 
     width: 100%;
     overflow: auto;
-    display: block;
 
     th {
       font-weight: bold;
     }
 
     th, td {
-      border: 1px solid #ddd;
       padding: 6px 13px;
+      border: 1px solid #ddd;
     }
 
     tr {
-      border-top: 1px solid #ccc;
       background-color: #fff;
+      border-top: 1px solid #ccc;
 
       &:nth-child(2n) {
         background-color: #f8f8f8;
@@ -227,13 +225,13 @@ $margin: 15px;
     overflow: hidden;
 
     & > span {
-      border: 1px solid #ddd;
       display: block;
       float: left;
-      overflow: hidden;
-      margin: 13px 0 0;
-      padding: 7px;
       width: auto;
+      padding: 7px;
+      margin: 13px 0 0;
+      overflow: hidden;
+      border: 1px solid #ddd;
     }
 
     span img {
@@ -242,10 +240,10 @@ $margin: 15px;
     }
 
     span span {
-      clear: both;
-      color: #333;
       display: block;
       padding: 5px 0 0;
+      clear: both;
+      color: #333;
     }
   }
 
@@ -256,8 +254,8 @@ $margin: 15px;
 
     & > span {
       display: block;
-      overflow: hidden;
       margin: 13px auto 0;
+      overflow: hidden;
       text-align: center;
     }
 
@@ -274,8 +272,8 @@ $margin: 15px;
 
     & > span {
       display: block;
-      overflow: hidden;
       margin: 13px 0 0;
+      overflow: hidden;
       text-align: right;
     }
 
@@ -287,9 +285,9 @@ $margin: 15px;
 
   span.float-left {
     display: block;
+    float: left;
     margin-right: 13px;
     overflow: hidden;
-    float: left;
 
     span {
       margin: 13px 0 0;
@@ -298,30 +296,29 @@ $margin: 15px;
 
   span.float-right {
     display: block;
+    float: right;
     margin-left: 13px;
     overflow: hidden;
-    float: right;
 
     & > span {
       display: block;
-      overflow: hidden;
       margin: 13px auto 0;
+      overflow: hidden;
       text-align: right;
     }
   }
 
   // Inline code snippets
   code, tt {
+    padding: 0;
     margin: 0;
-    border: 1px solid #ddd;
     background-color: #f8f8f8;
-    border-radius:3px;
+    border: 1px solid #ddd;
+    border-radius:3px; // don't add padding, gives scrollbars
 
-    padding: 0; // don't add padding, gives scrollbars
-
-    &:before, &:after { // this creates padding
+    &:before, &:after {
+      letter-spacing: -0.2em; // this creates padding
       content: "\00a0";
-      letter-spacing: -0.2em;
     }
 
     br { display: none; }
@@ -331,20 +328,20 @@ $margin: 15px;
 
   // Code tags within code blocks (<pre>s)
   pre > code {
-    margin: 0;
     padding: 0;
+    margin: 0;
     white-space: pre;
-    border: none;
     background: transparent;
+    border: none;
   }
 
   .highlight pre, pre {
-    background-color: #f8f8f8;
-    border: 1px solid #ddd;
+    padding: 6px 10px;
+    overflow: auto;
     font-size: 13px;
     line-height: 19px;
-    overflow: auto;
-    padding: 6px 10px;
+    background-color: #f8f8f8;
+    border: 1px solid #ddd;
     border-radius:3px;
   }
 
@@ -353,15 +350,15 @@ $margin: 15px;
   }
 
   pre code, pre tt {
-    margin: 0;
-    padding: 0;
-    background-color: transparent;
-    border: none;
-    word-wrap: normal;
-    max-width: initial;
     display: inline;
+    max-width: initial;
+    padding: 0;
+    margin: 0;
     overflow: initial;
     line-height: inherit;
+    word-wrap: normal;
+    background-color: transparent;
+    border: none;
 
     &:before, &:after {
       content: normal;


### PR DESCRIPTION
I was about to replace the nasty base64 encoded image for the markdown `<hr>` elements with a CSS version, but I thought it might be a good time to kill this outdated styling altogether.

What do people think of replacing the diagonal stripes with a simple divider?

![hr](https://cloud.githubusercontent.com/assets/6104/3649951/54b96466-1117-11e4-964a-f88d93a2fedb.gif)

Note: this diff is pretty noise because I reordered the rules with CSScomb.

/cc @github/design @github/markdown
