### PR TITLE
Remove explicit code/tt color

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "primer-user-content",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "keywords": [
     "github",
     "markdown",

--- a/components/markdown.scss
+++ b/components/markdown.scss
@@ -333,7 +333,6 @@ $margin: 16px;
     padding-bottom: 0.2em;
     margin: 0;
     font-size: 85%;
-    color: #555;
     background-color: #f7f7f7;
     border-radius: 3px; // don't add padding, gives scrollbars
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "primer-user-content",
   "description": "GitHub stylesheets for rendering markdown and syntax highlighting.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "keywords": [
     "github",
     "markdown",


### PR DESCRIPTION
We introduced an explicit color for `code` and `tt` elements with the recent typography changes. Since commit references are structured as `<a>` > `<tt>` in comments, the SHA is gray and doesn't appear clickable (reported by @aroben in https://github.com/github/github/issues/30469).

![screen shot 2014-08-05 at 10 50 46 am](https://cloud.githubusercontent.com/assets/6104/3813052/e74353ca-1caf-11e4-9345-bdb9079e5ed6.png)

This removes the `color` rule entirely so that the references will be blue again.

![screen shot 2014-08-05 at 10 51 30 am](https://cloud.githubusercontent.com/assets/6104/3813066/027e5752-1cb0-11e4-90f1-05950fe0051c.png)

As a result, `code` blocks will go from `#555` to `#333`, but I don't think that's a bad thing.

Before:

![screen shot 2014-08-05 at 10 35 36 am](https://cloud.githubusercontent.com/assets/6104/3813081/1baebd16-1cb0-11e4-833f-8fbae3652f35.png)

After:

![screen shot 2014-08-05 at 10 35 44 am](https://cloud.githubusercontent.com/assets/6104/3813082/205c5936-1cb0-11e4-8f90-50c915e966bc.png)

/cc @mdo @tobiasahlin 
