### PR TITLE
Make h1 and h2 headings bold like the others

### DIFF
--- a/components/markdown.scss
+++ b/components/markdown.scss
@@ -75,7 +75,6 @@ $margin: 16px;
     padding-bottom: 0.3em;
     margin-bottom: $margin;
     font-size: 2.25em;
-    font-weight: normal;
     line-height: 1.2;
     border-bottom: 1px solid #eee;
   }
@@ -84,7 +83,6 @@ $margin: 16px;
     padding-bottom: 0.3em;
     margin-bottom: $margin;
     font-size: 1.75em;
-    font-weight: normal;
     line-height: 1.225;
     border-bottom: 1px solid #eee;
   }


### PR DESCRIPTION
After seeing this in the wild for almost a day and hearing some feedback, I think we should go with making all of the headers (`<h1>` - `<h6>`) bold. The visual hierarchy just feels a little awkward with mixing bold and normal.

/cc @mdo @tobiasahlin @cameronmcefee 
