### PR TITLE
Segoe UI for Windows Markdown

### DIFF
--- a/components/markdown.scss
+++ b/components/markdown.scss
@@ -6,7 +6,7 @@ $margin: 16px;
 // includes some GitHub Flavored Markdown specific styling (like @mentions)
 .markdown-body {
   overflow: hidden;
-  font-family: "Helvetica Neue", Helvetica, Arial, freesans, sans-serif;
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, freesans, sans-serif;
 
   font-size: 16px;
   line-height: 1.6;


### PR DESCRIPTION
![](http://cl.ly/image/2N0g23333x2i/content#png)

Thoughts? This is with `font-size: 15px` (for some reason, Segoe always looks better when the font size is an odd number), I'm not sure how to do that via pure CSS though, probably need a "If Windows" stylesheet. Just changing it to Segoe looks better too though:

![](http://cl.ly/image/3l2w032b3y3d/content#png)
