### PR TITLE
Missed the base number literal class

### DIFF
--- a/components/syntax-pygments.scss
+++ b/components/syntax-pygments.scss
@@ -80,7 +80,7 @@
   .kt { color: #945277; font-weight: bold }
 
   // Literal.Number
-  .m { color: #009999 }
+  .m { color: #945277 }
 
   // Literal.String
   .s { color: #df5000 }


### PR DESCRIPTION
Just missed a number type which was affecting the way css was rendered vs scss (which was rendered correctly)

**Before**
![image](https://cloud.githubusercontent.com/assets/143418/4410616/60dc5aec-44e7-11e4-9838-9dca1205583b.png)

**After**
![image](https://cloud.githubusercontent.com/assets/143418/4410618/6b388380-44e7-11e4-9a16-f2c55adc928a.png)

/cc @mdo @jasonlong 
