### PR TITLE
Revert keyword type change

### DIFF
--- a/components/syntax-pygments.scss
+++ b/components/syntax-pygments.scss
@@ -38,7 +38,7 @@
   }
 
   // Keyword.Type
-  .kt { color: #945277 }
+  .kt { color: #458 }
 
   .c,   // Comment
   .cm,  // Comment.Multiline


### PR DESCRIPTION
Changes to `keyword.type` made keywords indistinguishable from functions in some languages. This change causes css scale types to appear differently than the associated number value, but I'm okay with compromising on that especially since it's current behavior :smirk: 

**Before**:
![image](https://cloud.githubusercontent.com/assets/143418/4447026/80f4fa0a-4807-11e4-8742-e7ea3b4b4bc0.png)

**After**:
![image](https://cloud.githubusercontent.com/assets/143418/4446865/0299af94-4806-11e4-8ca2-76aa9dcf2a1e.png)

CSS:

**Before**:
![image](https://cloud.githubusercontent.com/assets/143418/4447003/331783f2-4807-11e4-9a4f-a3a6eee2475e.png)

**After**:
![image](https://cloud.githubusercontent.com/assets/143418/4447040/9dd98424-4807-11e4-8829-4e31be091eac.png)

/cc @aroben @mdo @jasonlong @tobiasahlin 
