### PR TITLE
Fix styling of closing brackets in Ruby interpolated strings

### DIFF
--- a/components/syntax-pygments.scss
+++ b/components/syntax-pygments.scss
@@ -56,8 +56,9 @@
     font-style: italic;
   }
 
-  .cp,  // Comment.Preproc
-  .cs   // Comment.Special
+  .cp,   // Comment.Preproc
+  .cs,   // Comment.Special
+  .cp .h // Closing bracket in Ruby interpolated strings. See https://github.com/atom/atom/issues/716.
   {
     color: #999;
     font-weight: bold;


### PR DESCRIPTION
We need to override the normal `.h` style in this case.

Back ported from https://github.com/github/github/pull/34936.

/cc @jonrohan 
