### PR TITLE
Fix emoji being shrunk by max-width on `img`

### DIFF
--- a/components/markdown.scss
+++ b/components/markdown.scss
@@ -496,6 +496,10 @@ $margin: 16px;
     -moz-box-sizing: border-box;
     box-sizing: border-box;
   }
+  
+  .emoji {
+    max-width: none;
+  }
 
   // Gollum Image Tags
 


### PR DESCRIPTION
This overrides the max-width set on `.markdown-body img`so that emoji imges won't get shrunk.

Fixes https://github.com/github/github/issues/39109.

![image](https://cloud.githubusercontent.com/assets/1153134/6427679/b3dbeb98-bf3c-11e4-9499-75944960e729.png)
