### PR TITLE
Remove link styles on non-link anchors in user content

### DIFF
--- a/components/markdown.scss
+++ b/components/markdown.scss
@@ -264,6 +264,14 @@ $margin: 16px;
     margin-bottom: 0 !important;
   }
 
+  // Anchors like <a name="examples">. These sometimes end up wrapped around
+  // text when users mistakenly forget to close the tag or use self-closing tag
+  // syntax. We don't want them to appear like links.
+  a:not(:link):not(:visited) {
+    color: inherit;
+    text-decoration: none;
+  }
+
   // Link Colors
   .absent {
     color: #c00;


### PR DESCRIPTION
It seems to be fairly common for users to write Markdown like the following:

``` markdown
<a name="examples" />
Examples
========

Here are some examples:
```

This will generate the following HTML:

``` html
<p><a name="examples" /></p>
<h2>Examples</h2>
<p>Here are some examples:</p>
```

github.com's current sanitizer (Sanitize 2.0.4) respects self-closing tag syntax (because it is built on top of libxml2, an XML parser, and self-closing tags are an XML thing). So when this gets run through Sanitize 2.0.4, you end up with the following HTML:

``` html
<p><a name="examples"></a></p>
<h2>Examples</h2>
<p>Here are some examples:</p>
```

However, both Sanitize 3.x and the new sanitizer we're developing for github.com are based on an HTML-compliant parser rather than libxml2. HTML parsers treat this markup differently, and produce the following:

``` html
<p><a name="examples"></a></p><a name="examples">
<h2>Examples</h2>
<p>Here are some examples:</p></a>
```

Browsers do the exact same thing given this HTML, as you can see in the [Live DOM Viewer](http://software.hixie.ch/utilities/js/live-dom-viewer/?%3C!DOCTYPE%20html%3E%0A%3Cp%3E%3Ca%20name%3D%22examples%22%20%2F%3E%3C%2Fp%3E%0A%3Ch2%3EExamples%3C%2Fh2%3E%0A%3Cp%3EHere%20are%20some%20examples%3A%3C%2Fp%3E%0A).

Forgetting to close a non-link anchor, or using self-closing tag syntax (which also leaves the tag unclosed) is not normally a problem. Browsers don't apply any styles to these elements by default, so many web authors never even notice they've made this mistake. But github.com applies link styles to all anchor elements whether or not they're actually links, so this mistake becomes very noticeable: suddenly large parts of your document are blue!

Changing all of github.com's CSS to only target `a:link` and `a:visited` elements would be a huge change that is probably not worth the effort. Instead, we'll remove the link styles from non-link anchor elements in user content.

/cc https://github.com/github/primer/pull/198 @mdo
