### PR TITLE
Make links in comments underlined on hover in Safari

### DIFF
--- a/components/markdown.scss
+++ b/components/markdown.scss
@@ -267,7 +267,10 @@ $margin: 16px;
   // Anchors like <a name="examples">. These sometimes end up wrapped around
   // text when users mistakenly forget to close the tag or use self-closing tag
   // syntax. We don't want them to appear like links.
-  a:not(:link):not(:visited) {
+  // FIXME: a:not(:link):not(:visited) would be a little clearer here (and
+  // possibly faster to match), but it breaks styling of <a href> elements due
+  // to https://bugs.webkit.org/show_bug.cgi?id=142737.
+  a:not([href]) {
     color: inherit;
     text-decoration: none;
   }


### PR DESCRIPTION
Safari 8 has a bug with the `a:not(:link):not(:visited)` selector we were using previously (see https://bugs.webkit.org/show_bug.cgi?id=142737). Now we use `a:not([href])` instead, which should cover all of the cases we care about (namely, `<a name="foo">` elements explicitly created using HTML syntax in Markdown).

/cc https://github.com/primer/user-content/issues/43 #41 @mdo @jasonlong @bleikamp 
