### PR TITLE
Fixin' some links in README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,12 +10,12 @@ Before you do, would you mind reading [this license agreement](CLA.md)? If you o
 
 ## Using the issue tracker
 
-The [issue tracker](https://github.com/twbs/bootstrap/issues) is the preferred channel for [bug reports](#bug-reports), [features requests](#feature-requests) and [submitting pull requests](#pull-requests), but please respect the following restrictions:
+The [issue tracker](https://github.com/primer/markdown/issues) is the preferred channel for [bug reports](#bug-reports), [features requests](#feature-requests) and [submitting pull requests](#pull-requests), but please respect the following restrictions:
 
 * Please **do not** use the issue tracker for personal support requests.
 * Please **do not** derail or troll issues. Keep the discussion on topic and respect the opinions of others.
 * Please **do not** open issues or pull requests regarding the code in [`Normalize`](https://github.com/necolas/normalize.css) (open them in their respective repositories).
-  
+
 ## Bug reports
 
 A bug is a _demonstrable problem_ that is caused by the code in the repository. Good bug reports are extremely helpful, so thanks!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Primer markdown styles
 
-Stylesheets for rendering GitHub Flavored Markdown and syntax highlighted code snippets (powered by Pygments). Built to be used with [Primer](/primer/primer).
+Stylesheets for rendering GitHub Flavored Markdown and syntax highlighted code snippets (powered by Pygments). Built to be used with [Primer](https://github.com/primer/primer).
 
 [**Read the Primer documentation**](http://primercss.io/markdown) to learn more.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Primer user content styles
+# Primer markdown styles
 
 Stylesheets for rendering GitHub Flavored Markdown and syntax highlighted code snippets (powered by Pygments). Built to be used with [Primer](/primer/primer).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Stylesheets for rendering GitHub Flavored Markdown and syntax highlighted code snippets (powered by Pygments). Built to be used with [Primer](/primer/primer).
 
-[**Read the Primer documentation**](http://primercss.io/user-content) to learn more.
+[**Read the Primer documentation**](http://primercss.io/markdown) to learn more.
 
 _**Heads up!** We love open source, but Primer and it's projects are unlikely to add new features that are not used in GitHub.com. It's first and foremost our CSS toolkit. We really love to share though, so hopefully that means we're still friends <3._
 
@@ -25,18 +25,18 @@ The GitHub user content stylesheets ship in two formats, CSS and SCSS.
 The stylesheets are written in SCSS and compiled to regular CSS. Also included is a [Gruntfile](Gruntfile.js) for local project development.
 
 1. Install `grunt-cli` globally with `npm install -g grunt-cli`.
-2. Navigate to the root `/user-content` directory, then run `npm install` to install the necessary dependencies.
+2. Navigate to the root `/markdown` directory, then run `npm install` to install the necessary dependencies.
 3. Done! Now you can run `grunt` from the command line to compile SCSS to CSS.
 
 **Unfamiliar with `npm`? Don't have node installed?** That's a-okay. npm stands for [node packaged modules](http://npmjs.org/) and is a way to manage development dependencies through node.js. [Download and install node.js](http://nodejs.org/download/) before proceeding.
 
 ## Contributing
 
-Please read through our [contributing guidelines](https://github.com/primer/user-content/blob/master/CONTRIBUTING.md). Included are directions for opening issues, coding standards, and notes on development.
+Please read through our [contributing guidelines](https://github.com/primer/markdown/blob/master/CONTRIBUTING.md). Included are directions for opening issues, coding standards, and notes on development.
 
 All HTML and CSS should conform to the [style guidelines](http://primercss.io/guidelines).
 
-Editor preferences are available in the [editor config](https://github.com/primer/user-content/blob/master/.editorconfig) for easy use in common text editors. Read more and download plugins at <http://editorconfig.org>.
+Editor preferences are available in the [editor config](https://github.com/primer/markdown/blob/master/.editorconfig) for easy use in common text editors. Read more and download plugins at <http://editorconfig.org>.
 
 ## Versioning
 


### PR DESCRIPTION
Looks like the repo changed its name at one point + a copy paste derp from twbs/bootstrap.

Speaking of which, it might be worth tweaking the “Feature Requests” guidelines in light of GH not really wanting any for Primer :-)