### PR TITLE
Remove overflow: hidden on `.markdown-body`

### DIFF
--- a/components/markdown.scss
+++ b/components/markdown.scss
@@ -250,7 +250,6 @@ $margin: 16px;
 // container with .markdown-body on it should render generally well. It also
 // includes some GitHub Flavored Markdown specific styling (like @mentions)
 .markdown-body {
-  overflow: hidden;
   font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, freesans, sans-serif;
   font-size: 16px;
   line-height: 1.6;


### PR DESCRIPTION
Ran into a bug where tooltips at the top of a blog and diffs were cut off by `.markdown-body`'s `overflow: hidden`. No one has a clue why we have that right now—could be `<table>` related?—so let's see what's up.