### PR TITLE
Changing to content-box on images

### DIFF
--- a/components/markdown.scss
+++ b/components/markdown.scss
@@ -496,8 +496,9 @@ $margin: 16px;
   // Images & Stuff
   img {
     max-width: 100%;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
+    // because we put padding on the images to hide header lines, and some people
+    // specify the width of their images in their markdown.
+    box-sizing: content-box;
     background-color: #fff;
 
     &[align=right] {


### PR DESCRIPTION
This is a small patch fix after shipping #53 

When the user specifies an image width, the padding makes the image distorted. Changing to `content-box` keeps the image to the specific width without distortion.