### PR TITLE
Make Windows color emoji work in Markdown content

### DIFF
--- a/components/markdown.scss
+++ b/components/markdown.scss
@@ -250,7 +250,7 @@ $margin: 16px;
 // container with .markdown-body on it should render generally well. It also
 // includes some GitHub Flavored Markdown specific styling (like @mentions)
 .markdown-body {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, freesans, sans-serif;
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, freesans, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
   font-size: 16px;
   line-height: 1.6;
   word-wrap: break-word;


### PR DESCRIPTION
Specifying Segoe UI Emoji gives us color emoji on Windows 8.1 and newer. Windows 7 and 8 will render monochrome emoji without any extra work on our part, but specifying Segoe UI Symbol gives us slightly better rendering in IE for a few glyphs. This also matches Primer's non-Markdown font stack.

/cc @jonrohan @mdo @josh @mislav @dgraham @niik @ammeep @shana