### PR TITLE
Rendering the strikethrough as a background

### DIFF
--- a/components/markdown.scss
+++ b/components/markdown.scss
@@ -641,8 +641,8 @@ $margin: 16px;
   strike,
   s {
     text-decoration: none;
-    background: linear-gradient(#333, #333) repeat-x left center;
-    background-size: 1px 1px;
+    background: linear-gradient(#333, #333) repeat-x left 56%;
+    background-size: 1px .1em;
   }
 
   // Code tags within code blocks (<pre>s)

--- a/components/markdown.scss
+++ b/components/markdown.scss
@@ -645,8 +645,6 @@ $margin: 16px;
     background-size: 1px 1px;
   }
 
-
-
   // Code tags within code blocks (<pre>s)
   pre > code {
     padding: 0;

--- a/components/markdown.scss
+++ b/components/markdown.scss
@@ -640,18 +640,12 @@ $margin: 16px;
   del,
   strike,
   s {
-    position: relative;
     text-decoration: none;
-
-    &:before {
-      position: absolute;
-      right: 0;
-      bottom: 45%;
-      left: 0;
-      content: "";
-      border-bottom: 1px solid #333;
-    }
+    background: linear-gradient(#333, #333) repeat-x left center;
+    background-size: 1px 1px;
   }
+
+
 
   // Code tags within code blocks (<pre>s)
   pre > code {

--- a/components/markdown.scss
+++ b/components/markdown.scss
@@ -254,7 +254,7 @@ $margin: 16px;
   font-size: 16px;
   line-height: 1.6;
   word-wrap: break-word;
-  
+
   // Clearfix on the markdown body
   &:before {
     display: table;
@@ -637,7 +637,21 @@ $margin: 16px;
     br { display: none; }
   }
 
-  del code { text-decoration: inherit; }
+  del,
+  strike,
+  s {
+    position: relative;
+    text-decoration: none;
+
+    &:before {
+      position: absolute;
+      right: 0;
+      bottom: 45%;
+      left: 0;
+      content: "";
+      border-bottom: 1px solid #333;
+    }
+  }
 
   // Code tags within code blocks (<pre>s)
   pre > code {


### PR DESCRIPTION
fixes https://github.com/primer/markdown/issues/37

This is a fix for the problem where a strikethrough on two different fonts doesn't line up. The strikethrough is rendered by the font, so using line-height will almost be impossible. What I did instead was to remove `text-decoration: line-through;` and render the line as a linear background through the `<del>` this will make the line consistent throughout the del, even if it wraps.

##### Before
<img width="497" alt="screen shot 2015-11-12 at 11 06 20 am" src="https://cloud.githubusercontent.com/assets/54012/11125915/7ca403f4-893a-11e5-9285-afe38877f36f.png">
##### After
<img width="452" alt="screen shot 2015-11-12 at 11 06 28 am" src="https://cloud.githubusercontent.com/assets/54012/11125920/8489a592-893a-11e5-8694-83ce6acd1026.png">
##### After wrapped
<img width="692" alt="screen shot 2015-11-12 at 12 37 55 pm" src="https://cloud.githubusercontent.com/assets/54012/11125922/86a7d524-893a-11e5-85a2-f61abfcc0ff9.png">

cc @muan @mdo @jasonlong @fionnayao