### PR TITLE
Add Apple Emoji to default font stack

### DIFF
--- a/components/markdown.scss
+++ b/components/markdown.scss
@@ -250,7 +250,7 @@ $margin: 16px;
 // container with .markdown-body on it should render generally well. It also
 // includes some GitHub Flavored Markdown specific styling (like @mentions)
 .markdown-body {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, freesans, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, freesans, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   font-size: 16px;
   line-height: 1.6;
   word-wrap: break-word;


### PR DESCRIPTION
Improves emoji color rendering in Chrome.

Also see https://github.com/primer/primer/pull/163.

-
To: @jonrohan 
CC: @mdo @aroben @mislav