### PR TITLE
Fixes #59

### DIFF
--- a/components/markdown.scss
+++ b/components/markdown.scss
@@ -524,6 +524,8 @@ $margin: 16px;
 
   .emoji {
     max-width: none;
+    // Override `<img>` styles so Emjois don't clash with zebra striping in our tables
+    background-color: transparent;
   }
 
   // Gollum Image Tags


### PR DESCRIPTION
Override background-color on `.emoji` so it doesn't look awkward in zebra striped tables.

/cc @cmrberry