### PR TITLE
Don't display anchor when printing

### DIFF
--- a/lib/markdown-body.scss
+++ b/lib/markdown-body.scss
@@ -57,6 +57,12 @@ $margin: 16px;
       outline: none;
     }
   }
+  
+  @media print {
+    .anchor {
+      display: none;
+    }
+  }
 
   p,
   blockquote,


### PR DESCRIPTION
We often print markdown docs or export them to PDF from Github.

Currently the anchors appear in the printed media:
![image](https://cloud.githubusercontent.com/assets/16327036/25151858/216df03c-2455-11e7-9372-4520516d4ca3.png)